### PR TITLE
add level as queryParam to Change log level

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
 Add API to get Keypass logLevel
 Fix log format according with IOTPv4
+Add allow to use level as logLevel to change log level
 
 1.1.0
 

--- a/src/main/java/es/tid/fiware/iot/ac/util/LogsEndpoint.java
+++ b/src/main/java/es/tid/fiware/iot/ac/util/LogsEndpoint.java
@@ -80,8 +80,13 @@ public class LogsEndpoint {
     @UnitOfWork
     public Response updateLogLevel(@Tenant String tenant,
                                    @Correlator String correlator,
-                                   @QueryParam("logLevel") String logLevel
+                                   @QueryParam("logLevel") String logLevel,
+                                   @QueryParam("level") String level
                                    ) {
+        // Allow level as well as logLevel
+        if (level != null) {
+            logLevel = level;
+        }
 
         // Check logLevel proposed
         if (logLevel != null) {
@@ -103,5 +108,6 @@ public class LogsEndpoint {
         }
 
     }
+
 
 }


### PR DESCRIPTION
Currently only logLevel was allowed.
With this PR level will be allowed as well.
i.e.:
```
curl -i -X PUT 'http://localhost:17070/admin/log?logLevel=debug' -H 'Fiware-Service: admin_domain'
curl -i -X PUT 'http://localhost:17070/admin/log?level=debug' -H 'Fiware-Service: admin_domain'
```