### PR TITLE
upgrade mysql connector from 5.1.47 to 5.1.49

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+ADD: upgrade java mysql connector from 5.1.47 to 5.1.49
 ADD: fix /opt/keypass directory to 1000 user for docker
 ADD: autoReconnect to jdbc url configuration (#116)
 ADD: disable usage of SSL for mysql in jdbc url configuration (#126)

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.47</version>
+            <version>5.1.49</version>
         </dependency>
         <dependency>
             <groupId>net.sf.ehcache</groupId>


### PR DESCRIPTION
https://mvnrepository.com/artifact/mysql/mysql-connector-java
5.1.47 Aug, 2018
5.1.49 Apr, 2020