### PR TITLE
set proper timezone in mysql jdbc driver uri

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+ADD: Fix serverTimezone to UTC in mysql jdbc driver uri
 ADD: upgrade java mysql connector from 5.1.49 to 8.0.16
 
 1.6.0

--- a/conf/config.yml
+++ b/conf/config.yml
@@ -30,7 +30,7 @@ database:
   password: keypass
 
   # the JDBC URL
-  url: jdbc:mysql://localhost/keypass?autoReconnect=true&useSSL=false
+  url: jdbc:mysql://localhost/keypass?autoReconnect=true&useSSL=false&serverTimezone=UTC
 
   # any properties specific to your JDBC driver:
   properties:

--- a/conf/config.yml_docker
+++ b/conf/config.yml_docker
@@ -30,7 +30,7 @@ database:
   password: keypass
 
   # the JDBC URL
-  url: jdbc:mysql://localhost/keypass?autoReconnect=true&useSSL=false
+  url: jdbc:mysql://localhost/keypass?autoReconnect=true&useSSL=false&serverTimezone=UTC
 
   # any properties specific to your JDBC driver:
   properties:


### PR DESCRIPTION
to avoid these kind of messages:
```
"The server time zone value ‘CEST’ is unrecognized"
```
Issued and fixed by @cesarjorgemartinez 