### PR TITLE
Change owner of /opt/keypass files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ RUN \
     apt-get -y remove maven && \
     apt-get -y autoremove --purge && \
     # Don't need old log files inside docker images
-    rm -f /var/log/*log
+    rm -f /var/log/*log && \
+    chown -R 1000:1000 /opt/keypass
 
 # Define the entry point
 ENTRYPOINT ["/opt/keypass/keypass-entrypoint.sh"]


### PR DESCRIPTION
Previous versions of keypass (1.9.0 and below) had all files in `/opt/keypass` belong to UID 1000. This made it possible to **run the container with an unprivileged user (UID 1000)**.

Version 1.11.0 dropped the `chown` from the Dockerfile and had all files in `/opt/keypass` owned by root. Since the `keypass-entrypoint.sh` performs some inline changes with `sed -i` in `/opt/keypass/config.yml`, it **requires keypass to be run as root (UID 0)**.

Changing the security profile impacts on the policies in container orchestration environments such as openshift. We could modify our security policies, but believe that actually keypass can run as un unprivileged user just fine, as long as it is the owner of the /`opt/keypass` folder and subfolders.

This PR restores ownership of the `/opt/keypass` folder to UID 1000, keeping backward compatibility with the security policy configured for keypass 1.9.0.