### PR TITLE
fix exception about InaccessibleObjectException

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+FIX: startup log exception about InaccessibleObjectException (#195)
 UPGRADE: Debian version from 12.4 to 12.6 in Dockerfile
 
 1.11.0

--- a/bin/keypass-entrypoint.sh
+++ b/bin/keypass-entrypoint.sh
@@ -16,6 +16,7 @@ echo "INFO: keypass entrypoint start"
 # LOG_LEVEL. Default INFO
 [[ "${KEYPASS_LOG_LEVEL}" == "" ]] && export KEYPASS_LOG_LEVEL=INFO
 
+export JDK_JAVA_OPTIONS='--add-opens java.base/java.lang=ALL-UNNAMED'
 
 # Check argument DB_HOST if provided
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
Partial fix for https://github.com/telefonicaid/fiware-keypass/issues/195, just for 

time=2024-09-16T10:18:52.610Z | lvl=ERROR | corr= | trans=n/a | srv= | subsrv=n/a | comp=KEYPASS | op=JavassistLazyInitializer | msg=HHH000142: Javassist Enhancement failed: es.tid.fiware.iot.ac.model.Policy
java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @26ee6b5e
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354) ~[na:na]
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297) ~[na:na]
        at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:200) ~[na:na]
        at java.base/java.lang.reflect.Method.setAccessible(Method.java:194) ~[na:na]
        at javassist.util.proxy.SecurityActions.setAccessible(SecurityActions.java:103) ~[keypass.jar:1.11.0]
        at javassist.util.proxy.FactoryHelper.toClass2(FactoryHelper.java:181) ~[keypass.jar:1.11.0]
        at javassist.util.proxy.FactoryHelper.toClass(FactoryHelper.java:164) ~[keypass.jar:1.11.0]
        at javassist.util.proxy.ProxyFactory.createClass3(ProxyFactory.java:507) ~[keypass.jar:1.11.0]
        at javassist.util.proxy.ProxyFactory.createClass2(ProxyFactory.java:492) ~[keypass.jar:1.11.0]
        at javassist.util.proxy.ProxyFactory.createClass1(ProxyFactory.java:428) ~[keypass.jar:1.11.0]
        at javassist.util.proxy.ProxyFactory.createClass(ProxyFactory.java:400) ~[keypass.jar:1.11.0]
        at org.hibernate.proxy.pojo.javassist.JavassistLazyInitializer.getProxyFactory(JavassistLazyInitializer.java:162) ~[keypass.jar:1.11.0]
        at org.hibernate.proxy.pojo.javassist.JavassistProxyFactory.postInstantiate(JavassistProxyFactory.java:67) ~[keypass.jar:1.11.0]
        at org.hibernate.tuple.entity.PojoEntityTuplizer.buildProxyFactory(PojoEntityTuplizer.java:224) ~[keypass.jar:1.11.0]
        at org.hibernate.tuple.entity.AbstractEntityTuplizer.<init>(AbstractEntityTuplizer.java:212) ~[keypass.jar:1.11.0]
        at org.hibernate.tuple.entity.PojoEntityTuplizer.<init>(PojoEntityTuplizer.java:80) ~[keypass.jar:1.11.0]
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:na]
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77) ~[na:na]
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[na:na]
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500) ~[na:na]
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481) ~[na:na]
        at org.hibernate.tuple.entity.EntityTuplizerFactory.constructTuplizer(EntityTuplizerFactory.java:135) ~[keypass.jar:1.11.0]
        at org.hibernate.tuple.entity.EntityTuplizerFactory.constructDefaultTuplizer(EntityTuplizerFactory.java:188) ~[keypass.jar:1.11.0]
        at org.hibernate.tuple.entity.EntityMetamodel.<init>(EntityMetamodel.java:403) ~[keypass.jar:1.11.0]
        at org.hibernate.persister.entity.AbstractEntityPersister.<init>(AbstractEntityPersister.java:520) ~[keypass.jar:1.11.0]
        at org.hibernate.persister.entity.SingleTableEntityPersister.<init>(SingleTableEntityPersister.java:148) ~[keypass.jar:1.11.0]
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:na]
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77) ~[na:na]
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[na:na]
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500) ~[na:na]
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481) ~[na:na]
        at org.hibernate.persister.internal.PersisterFactoryImpl.create(PersisterFactoryImpl.java:163) ~[keypass.jar:1.11.0]
        at org.hibernate.persister.internal.PersisterFactoryImpl.createEntityPersister(PersisterFactoryImpl.java:135) ~[keypass.jar:1.11.0]
        at org.hibernate.internal.SessionFactoryImpl.<init>(SessionFactoryImpl.java:401) ~[keypass.jar:1.11.0]
        at org.hibernate.cfg.Configuration.buildSessionFactory(Configuration.java:1857) ~[keypass.jar:1.11.0]
        at io.dropwizard.hibernate.SessionFactoryFactory.buildSessionFactory(SessionFactoryFactory.java:85) ~[keypass.jar:1.11.0]
        at io.dropwizard.hibernate.SessionFactoryFactory.build(SessionFactoryFactory.java:40) ~[keypass.jar:1.11.0]
        at io.dropwizard.hibernate.SessionFactoryFactory.build(SessionFactoryFactory.java:30) ~[keypass.jar:1.11.0]
        at io.dropwizard.hibernate.HibernateBundle.run(HibernateBundle.java:38) ~[keypass.jar:1.11.0]
        at io.dropwizard.hibernate.HibernateBundle.run(HibernateBundle.java:13) ~[keypass.jar:1.11.0]
        at io.dropwizard.setup.Bootstrap.run(Bootstrap.java:176) ~[keypass.jar:1.11.0]
        at io.dropwizard.cli.EnvironmentCommand.run(EnvironmentCommand.java:41) ~[keypass.jar:1.11.0]
        at io.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:76) ~[keypass.jar:1.11.0]
        at io.dropwizard.cli.Cli.run(Cli.java:70) ~[keypass.jar:1.11.0]
        at io.dropwizard.Application.run(Application.java:72) ~[keypass.jar:1.11.0]
        at es.tid.fiware.iot.ac.AcService.main(AcService.java:59) ~[keypass.jar:1.11.0]