### PR TITLE
fix log error about liquidbased at startup

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+FIX: startup error log about liquidbase (#171)
 UPGRADE: Debian version from 12.4 to 12.6 in Dockerfile
 
 1.11.0

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,11 @@
           <artifactId>jaxb-runtime</artifactId>
           <version>2.3.2</version>
         </dependency>
+        <dependency>
+          <groupId>org.liquibase</groupId>
+          <artifactId>liquibase-core</artifactId>
+          <version>4.3.5</version>
+        </dependency>
     </dependencies>
 
     <properties>


### PR DESCRIPTION
fix for https://github.com/telefonicaid/fiware-keypass/issues/171

Exception in thread "main" java.lang.ClassCastException: class java.time.LocalDateTime cannot be cast to class java.lang.String (java.time.LocalDateTime and java.lang.String are in module java.base of loader 'bootstrap')
        at liquibase.changelog.StandardChangeLogHistoryService.getRanChangeSets(StandardChangeLogHistoryService.java:214)
        at liquibase.changelog.AbstractChangeLogHistoryService.upgradeChecksums(AbstractChangeLogHistoryService.java:68)
        at liquibase.changelog.StandardChangeLogHistoryService.upgradeChecksums(StandardChangeLogHistoryService.java:180)
        at liquibase.Liquibase.checkLiquibaseTables(Liquibase.java:727)
        at liquibase.Liquibase.update(Liquibase.java:196)
        at liquibase.Liquibase.update(Liquibase.java:181)
        at io.dropwizard.migrations.DbMigrateCommand.run(DbMigrateCommand.java:57)
        at io.dropwizard.migrations.DbCommand.run(DbCommand.java:52)
        at io.dropwizard.migrations.AbstractLiquibaseCommand.run(AbstractLiquibaseCommand.java:63)
        at io.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:76)
        at io.dropwizard.cli.Cli.run(Cli.java:70)
        at io.dropwizard.Application.run(Application.java:72)
        at es.tid.fiware.iot.ac.AcService.main(AcService.java:59)